### PR TITLE
:sparkles::construction: [Feature/component/#15] 이메일 회원가입/로그인 API 연동 후 로직 구현 & 사용자 정보 저장하는 atom 생성

### DIFF
--- a/solumon-front/src/recoil/AllAtom.js
+++ b/solumon-front/src/recoil/AllAtom.js
@@ -7,3 +7,19 @@ export const UserInterestTopic = atom({
     interests: ['연애', '드라마/영화', '다이어트'],
   },
 });
+
+// export const kakaoToken = atom({
+//   key: 'kakaoToken',
+//   default: '',
+// });
+
+export const GeneralUserInfo = atom({
+  key: 'GeneralUserInfo',
+  default: [
+    {
+      accessToken: '',
+      firstLogIn: true,
+      memberId: 0,
+    },
+  ],
+});


### PR DESCRIPTION
- 이메일 인증 메일 전송 API 연결
- 이메일 회원가입 정보 post 하는 API 연결
- 이메일 로그인 정보 post 하는 API 연결
- API response에 따른 로직 구현
- 사용자 정보(인증 토큰, 첫 로그인 여부, 멤버 ID)를 저장하는 GeneralUserInfo Atom 생성
-> 닉네임이나 이메일도 저장해야 한다면 default 값을 수정할 예정