### PR TITLE
🚧🎨✨[Feature/component/#15] 게시글 관련 페이지들 변경사항

### DIFF
--- a/solumon-front/src/components/PostCard.jsx
+++ b/solumon-front/src/components/PostCard.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import styled, { ThemeProvider } from 'styled-components';
 import theme from '../style/theme';
 import PropTypes from 'prop-types';
@@ -6,14 +6,16 @@ import PropTypes from 'prop-types';
 import { BsChatDots } from 'react-icons/bs';
 import { VscGraph } from 'react-icons/vsc';
 
-function PostCard({ postData, postCount }) {
+function PostCard({ postData, postCount, postOrder }) {
+  const postInfo = postData[postOrder] || [];
+
   return (
     <ThemeProvider theme={theme}>
       <Wrapper>
         <Container>
           {postData && postCount
-            ? postData.slice(0, postCount).map((post) => (
-                <CardWrapper key={post.post_id}>
+            ? postInfo.slice(0, postCount).map((post) => (
+                <CardWrapper key={post.post_id} to={`/posts/${post.post_id}`}>
                   <StyledThumbnail
                     src={
                       post.image_url ||
@@ -22,26 +24,28 @@ function PostCard({ postData, postCount }) {
                   ></StyledThumbnail>
                   <PostPreview>
                     <Title>{post.title}</Title>
-                    <Content>{post.preview}</Content>
+                    <Content>{post.contents}</Content>
                     <PostInfo>
-                      <Date>{post.created_at}</Date>
-                      <ChatCount>
-                        <BsChatDots />
-                        {post.chat_count}명 참여
-                      </ChatCount>
-                      <VoteCount>
-                        <VscGraph />
-                        {post.vote_count}명 참여
-                      </VoteCount>
+                      <Date>{post.created_at.slice(0, 10)}</Date>
+                      <CountWrapper>
+                        <ChatCount>
+                          <BsChatDots />
+                          {post.chat_count}명 참여
+                        </ChatCount>
+                        <VoteCount>
+                          <VscGraph />
+                          {post.vote_count}명 참여
+                        </VoteCount>
+                      </CountWrapper>
                     </PostInfo>
                     <Line></Line>
-                    <Writer>by. {post.writer}</Writer>
+                    <Writer>by. {post.nickname}</Writer>
                   </PostPreview>
                 </CardWrapper>
               ))
-            : postData &&
-              postData.map((post) => (
-                <CardWrapper key={post.post_id}>
+            : postData
+            ? postData.map((post) => (
+                <CardWrapper key={post.post_id} to={`/posts/${post.post_id}`}>
                   <StyledThumbnail
                     src={
                       post.image_url ||
@@ -50,23 +54,28 @@ function PostCard({ postData, postCount }) {
                   ></StyledThumbnail>
                   <PostPreview>
                     <Title>{post.title}</Title>
-                    <Content>{post.preview}</Content>
+                    <Content>{post.contents}</Content>
                     <PostInfo>
-                      <Date>{post.created_at}</Date>
-                      <ChatCount>
-                        <BsChatDots />
-                        {post.chat_count}명 참여
-                      </ChatCount>
-                      <VoteCount>
-                        <VscGraph />
-                        {post.vote_count}명 참여
-                      </VoteCount>
+                      <Date>{post.created_at.slice(0, 10)}</Date>
+                      <CountWrapper>
+                        <ChatCount>
+                          <BsChatDots />
+                          {post.chat_count}명 참여
+                        </ChatCount>
+                        <VoteCount>
+                          <VscGraph />
+                          {post.vote_count}명 참여
+                        </VoteCount>
+                      </CountWrapper>
                     </PostInfo>
                     <Line></Line>
-                    <Writer>by. {post.writer}</Writer>
+                    <Writer>by. {post.nickname}</Writer>
                   </PostPreview>
                 </CardWrapper>
-              ))}
+              ))
+            : postInfo.length === 0 && (
+                <div>해당 데이터가 존재하지 않습니다.</div>
+              )}
         </Container>
       </Wrapper>
     </ThemeProvider>
@@ -76,12 +85,14 @@ function PostCard({ postData, postCount }) {
 PostCard.propTypes = {
   postData: PropTypes.array.isRequired,
   postCount: PropTypes.number,
+  postOrder: PropTypes.string,
 };
 
 export default PostCard;
 
 const Wrapper = styled.div`
   width: 1280px;
+  /* min-height: 640px; */
 `;
 
 const Container = styled.div`
@@ -91,11 +102,12 @@ const Container = styled.div`
   gap: 20px;
 `;
 
-const CardWrapper = styled.div`
+const CardWrapper = styled(Link)`
   width: 240px;
-  height: 310px;
+  min-height: 310px;
   border-radius: 10px;
   background-color: ${({ theme }) => theme.linen};
+  text-decoration: none;
 `;
 
 const StyledThumbnail = styled.img`
@@ -109,7 +121,7 @@ const PostPreview = styled.div`
 `;
 
 const Title = styled.h1`
-  font-size: 14px;
+  font-size: 16px;
   font-weight: 600;
   color: ${({ theme }) => theme.dark_purple};
   white-space: nowrap;
@@ -119,25 +131,30 @@ const Title = styled.h1`
 `;
 
 const Content = styled.p`
-  font-size: 12px;
+  font-size: 14px;
   color: ${({ theme }) => theme.dark_purple};
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 3;
   overflow: hidden;
-  margin-bottom: 25px;
+  margin-bottom: 30px;
 `;
 
 const PostInfo = styled.div`
   display: flex;
-  font-size: 10px;
+  flex-direction: column;
+  font-size: 12px;
   color: ${({ theme }) => theme.medium_purple};
-  align-items: center;
-  gap: 15px;
+  gap: 10px;
   margin-bottom: 10px;
 `;
 
 const Date = styled.span``;
+
+const CountWrapper = styled.div`
+  display: flex;
+  gap: 20px;
+`;
 
 const ChatCount = styled.span`
   display: flex;
@@ -159,5 +176,5 @@ const Writer = styled.p`
   font-size: 13px;
   font-weight: 500;
   color: ${({ theme }) => theme.dark_purple};
-  padding: 5px 0;
+  padding: 2px 0;
 `;

--- a/solumon-front/src/components/SortSelector.jsx
+++ b/solumon-front/src/components/SortSelector.jsx
@@ -1,30 +1,38 @@
+import { useState, useEffect } from 'react';
 import styled, { ThemeProvider } from 'styled-components';
 import theme from '../style/theme';
-import { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+function SortSelector({ sortLabels, defaultSort, onClick }) {
+  const [sortValue, setSortValue] = useState(sortLabels[defaultSort]);
 
-function SortSelector() {
-  const [sortStandard, setSortStandard] = useState('최신순');
+  const handleChangeSortStandard = (e) => {
+    const newValue = e.target.value;
+    setSortValue(newValue);
+    onClick(newValue); // 새로운 탭을 클릭할 때 콜백 함수 호출
+  };
 
   useEffect(() => {
-    console.log(sortStandard);
-  }, [sortStandard]);
+    console.log(sortValue);
+  }, [sortValue]);
 
   return (
     <ThemeProvider theme={theme}>
       <Wrapper>
-        <StyledSelect
-          name="sort"
-          onChange={(e) => setSortStandard(e.target.value)}
-        >
-          <StyledOption value="latest">최신순</StyledOption>
-          <StyledOption value="chatCount">채팅 참여 순</StyledOption>
-          <StyledOption value="voteCount">투표 참여 순</StyledOption>
-          <StyledOption value="deadline">마감 임박 순</StyledOption>
+        <StyledSelect value={sortValue} onChange={handleChangeSortStandard}>
+          {sortLabels.map((label, idx) => (
+            <StyledOption key={idx}>{label}</StyledOption>
+          ))}
         </StyledSelect>
       </Wrapper>
     </ThemeProvider>
   );
 }
+
+SortSelector.propTypes = {
+  sortLabels: PropTypes.arrayOf(PropTypes.string).isRequired,
+  defaultSort: PropTypes.number.isRequired,
+  onClick: PropTypes.func.isRequired,
+};
 
 export default SortSelector;
 

--- a/solumon-front/src/pages/PostCategory.jsx
+++ b/solumon-front/src/pages/PostCategory.jsx
@@ -1,8 +1,8 @@
 import { useState, useEffect } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
+import axios from 'axios';
 import styled, { ThemeProvider } from 'styled-components';
 import theme from '../style/theme';
-import PropTypes from 'prop-types';
 
 import { CiSearch } from 'react-icons/ci';
 import TabsComponent from '../components/TabsComponent';
@@ -11,130 +11,170 @@ import PostCard from '../components/PostCard';
 import Pagination from '../components/Pagination';
 
 function PostCategory() {
+  const userInfo = JSON.parse(window.localStorage.getItem('userInfo'));
+  const USER_TOKEN = userInfo.accessToken;
+
   const [postData, setPostData] = useState([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const [postDataLength, setPostDataLength] = useState(0);
   const [selectedTab, setSelectedTab] = useState('진행중인 고민');
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const postType = searchParams.get('postType');
+  let postType = searchParams.get('postType');
   let postStatus = searchParams.get('postStatus');
-  const postOrder = searchParams.get('postOrder');
-  const currentPage = parseInt(searchParams.get('page')) || 1; // 현재 페이지 가져오기
-
-  const postPerPage = 10; // 한 페이지당 렌더링할 게시글 수
-  const indexOfLastPost = currentPage * postPerPage; // 한 페이지의 마지막 게시글의 인덱스
-  const indexOfFirstPost = indexOfLastPost - postPerPage; // 한 페이지의 첫 번째 게시글의 인덱스
-  const currentPosts = postData.slice(indexOfFirstPost, indexOfLastPost); // 해당 페이지에서 보여줄 데이터 나누기
+  let postOrder = searchParams.get('postOrder');
+  let currentPage = parseInt(searchParams.get('pageNum')) || 1; // 현재 페이지 가져오기
 
   let categoryTitle = '';
-  const categoryPrefix = postType === 'interest' ? '[관심주제] ' : '';
+  const categoryPrefix = postType === 'INTEREST' ? '[관심주제] ' : '';
 
   if (
-    (postType === 'general' || postType === 'interest') &&
-    postStatus !== 'completed'
+    (postType === 'GENERAL' || postType === 'INTEREST') &&
+    postStatus !== 'COMPLETED'
   ) {
-    if (postOrder === 'mostChatParticipants') {
+    if (postOrder === 'MOST_CHAT_PARTICIPANTS') {
       categoryTitle = categoryPrefix + '채팅 참여자가 많은 고민';
-    } else if (postOrder === 'mostVotes') {
+    } else if (postOrder === 'MOST_VOTES') {
       categoryTitle = categoryPrefix + '투표 참여자가 많은 고민';
-    } else if (postStatus === 'ongoing') {
-      if (postOrder === 'latest') {
+    } else if (postStatus === 'ONGOING') {
+      if (postOrder === 'LATEST') {
         categoryTitle = categoryPrefix + '아직 결정하지 못한 고민';
-      } else if (postOrder === 'imminentDeadline') {
+      } else if (postOrder === 'IMMINENT_CLOSE') {
         categoryTitle = categoryPrefix + '결정 시간이 임박한 고민';
       }
     }
   } else if (
-    (postType === 'interest' || postType === 'general') &&
-    postStatus === 'completed' &&
-    postOrder === 'latest'
+    (postType === 'INTEREST' || postType === 'GENERAL') &&
+    postStatus === 'COMPLETED' &&
+    postOrder === 'LATEST'
   ) {
     categoryTitle = categoryPrefix + '결정이 완료된 고민';
   }
+
+  const handleSortChange = (sortValue) => {
+    if (sortValue === '최신순') {
+      setSearchParams({
+        postType: postType,
+        postStatus: postStatus,
+        postOrder: 'LATEST',
+        pageNum: currentPage,
+      });
+    } else if (sortValue === '채팅 참여 순') {
+      setSearchParams({
+        postType: postType,
+        postStatus: postStatus,
+        postOrder: 'MOST_CHAT_PARTICIPANTS',
+        pageNum: currentPage,
+      });
+    } else if (sortValue === '투표 참여 순') {
+      setSearchParams({
+        postType: postType,
+        postStatus: postStatus,
+        postOrder: 'MOST_VOTES',
+        pageNum: currentPage,
+      });
+    } else {
+      setSearchParams({
+        postType: postType,
+        postStatus: postStatus,
+        postOrder: 'IMMINENT_CLOSE',
+        pageNum: currentPage,
+      });
+    }
+    console.log(sortValue);
+  };
 
   const onTabChange = (newTab) => {
     if (newTab === '진행중인 고민') {
       // 클릭한 탭에 따라 쿼리값 변경
       setSearchParams({
         postType: postType,
-        postStatus: 'ongoing',
+        postStatus: 'ONGOING',
         postOrder: postOrder,
-        page: currentPage,
+        pageNum: currentPage,
       });
     } else {
       setSearchParams({
         postType: postType,
-        postStatus: 'completed',
+        postStatus: 'COMPLETED',
         postOrder: postOrder,
-        page: currentPage,
+        pageNum: currentPage,
       });
     }
     // 클릭된 탭에 따라 어떤 데이터를 불러올지 결정
     setSelectedTab(newTab);
   };
 
-  const onPageChange = (newPage) => {
+  const handlePageChange = (newPage) => {
     setSearchParams({
       postType: postType,
       postStatus: postStatus,
       postOrder: postOrder,
-      page: newPage,
+      pageNum: newPage,
     });
   };
 
-  const fetchData = () => {
-    fetch(
-      `https://jsonplaceholder.typicode.com/posts?postType=${postType}&postStatus=${postStatus}&postOrder=${postOrder}&page=${currentPage}`,
-    )
-      .then((response) => {
-        return response.json();
-      })
-      .then((json) => {
-        setPostData(json);
-        setIsLoading(false);
-      })
-      .catch((error) => {
-        console.log(`Something Wrong: ${error}`);
-        setIsLoading(false);
-      });
+  const fetchData = async () => {
+    try {
+      const response = await axios.get(
+        `http://solumon.site:8080/posts?postType=${postType}&postStatus=${postStatus}&postOrder=${postOrder}&pageNum=${currentPage}`,
+        {
+          headers: {
+            'X-AUTH-TOKEN': USER_TOKEN,
+            'Content-Type': 'application/json',
+          },
+          withCredentials: true,
+        },
+      );
+      if (response.status === 200) {
+        const json = response.data;
+        setPostDataLength(json.totalElements);
+        setPostData(json.content);
+      } else {
+        console.error('로딩 실패');
+      }
+    } catch (error) {
+      console.log(`Something Wrong: ${error.message}`);
+    }
   };
 
   useEffect(() => {
-    setIsLoading(true);
     fetchData();
   }, [postType, postStatus, postOrder, currentPage]);
 
   return (
     <ThemeProvider theme={theme}>
       <Wrapper>
-        {isLoading ? (
-          <div>로딩 중입니다.</div>
-        ) : (
-          <>
-            <PostSection>
-              <TitleWrapper>
-                <CategoryTitle>{categoryTitle}</CategoryTitle>
-                <Link to={'/posts/search'}>
-                  <SearchIcon />
-                </Link>
-              </TitleWrapper>
-              <SortWrapper>
-                <TabsComponent
-                  tabLabels={['진행중인 고민', '결정이 완료된 고민']}
-                  defaultTab={0}
-                  onClick={onTabChange}
-                />
-                <SortSelector />
-              </SortWrapper>
-              <PostCard postData={currentPosts} />
-            </PostSection>
-            <Pagination
-              totalPages={Math.ceil(postData.length / postPerPage)}
-              currentPage={currentPage}
-              onPageChange={onPageChange}
+        <PostSection>
+          <TitleWrapper>
+            <CategoryTitle>{categoryTitle}</CategoryTitle>
+            <Link to={'/search'}>
+              <SearchIcon />
+            </Link>
+          </TitleWrapper>
+          <SortWrapper>
+            <TabsComponent
+              tabLabels={['진행중인 고민', '결정이 완료된 고민']}
+              defaultTab={0}
+              onClick={onTabChange}
             />
-          </>
-        )}
+            <SortSelector
+              sortLabels={[
+                '최신순',
+                '채팅 참여 순',
+                '투표 참여 순',
+                '마감 임박 순',
+              ]}
+              defaultSort={0}
+              onClick={handleSortChange}
+            />
+          </SortWrapper>
+          <PostCard postData={postData} />
+        </PostSection>
+        <Pagination
+          totalPages={Math.ceil(postDataLength / 10)}
+          currentPage={currentPage}
+          onPageChange={handlePageChange}
+        />
       </Wrapper>
     </ThemeProvider>
   );
@@ -176,5 +216,5 @@ const SortWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 10px;
+  margin-bottom: 20px;
 `;

--- a/solumon-front/src/pages/PostList.jsx
+++ b/solumon-front/src/pages/PostList.jsx
@@ -4,6 +4,7 @@ import axios from 'axios';
 import styled, { ThemeProvider } from 'styled-components';
 import theme from '../style/theme';
 
+import { CiSearch } from 'react-icons/ci';
 import PostCard from '../components/PostCard';
 
 const postInfoList = [
@@ -26,9 +27,34 @@ const postInfoList = [
 
 function PostList() {
   const [postData, setPostData] = useState([]);
+  const [interestPostData, setInterestPostData] = useState([]);
 
   const userInfo = JSON.parse(window.localStorage.getItem('userInfo'));
   const USER_TOKEN = userInfo.accessToken;
+  const USER_INTERESTS = userInfo.interests;
+
+  const fetchInterestsData = async () => {
+    try {
+      const response = await axios.get(
+        `http://solumon.site:8080/posts?postType=INTEREST&postStatus=ONGOING&postOrder=LATEST&pageNum=1`,
+        {
+          headers: {
+            'X-AUTH-TOKEN': USER_TOKEN,
+            'Content-Type': 'application/json',
+          },
+          withCredentials: true,
+        },
+      );
+      if (response.status === 200) {
+        const json = response.data;
+        setInterestPostData(json.content);
+      } else {
+        console.error('로딩 실패');
+      }
+    } catch (error) {
+      console.log(`Something Wrong: ${error.message}`);
+    }
+  };
 
   const fetchData = () => {
     const fetchDataPromises = postInfoList.map((item) =>
@@ -73,6 +99,10 @@ function PostList() {
 
   useEffect(() => {
     fetchData(); // 초기 렌더링 시 한 번 호출
+    if (USER_INTERESTS.length > 0) {
+      fetchInterestsData();
+    }
+    console.log(interestPostData);
   }, []);
 
   useEffect(() => {
@@ -83,6 +113,22 @@ function PostList() {
   return (
     <ThemeProvider theme={theme}>
       <Wrapper>
+        <Link to={'/search'}>
+          <SearchIcon />
+        </Link>
+
+        <PostSection>
+          <SectionTitle>관심주제와 관련된 고민들</SectionTitle>
+          <AllPostsLink
+            to={
+              '/posts?postType=INTEREST&postStatus=ONGOING&postOrder=LATEST&pageNum=1'
+            }
+          >
+            전체보기 {'>'}
+          </AllPostsLink>
+          <PostCard postData={interestPostData} postCount={5} />
+        </PostSection>
+
         {postInfoList.map((item, idx) => (
           <PostSection key={idx}>
             <SectionTitle>{item.title}</SectionTitle>
@@ -105,6 +151,15 @@ export default PostList;
 const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
+`;
+
+const SearchIcon = styled(CiSearch)`
+  width: 28px;
+  height: 28px;
+  color: ${({ theme }) => theme.dark_purple};
+  float: right;
+  margin-top: 20px;
+  margin-right: 115px;
 `;
 
 const PostSection = styled.div`


### PR DESCRIPTION
> COMPONENT

SortSelect
- 외부에서 받아온 props 값으로 옵션 생성하도록 변경 
- sort 값 바꿔주는 handleChangeSortStandard 함수 추가

PostCard
- 받아올 데이터 키값 서버 응답에 맞게 수정
- 게시글 날짜 '연도-월-일' 까지만 보이도록 수정
- 게시글 카드 클릭 시 해당 id 로 이동하도록 링크 추가
- PostList 페이지에서 데이터 넘길 때 주제 별 데이터 순서에 맞게 렌더링하도록 props로 postOrder 값 추가


> PAGE

PostList
- 검색 페이지로 이동하는 검색 아이콘 추가
- 관심주제 관련 게시글 요청하는 API 연동 & 게시글 렌더링하는 코드 추가 -> 나중에 수정해야 할듯

PostCategory
- 게시글 요청하는 API 연동
- 백엔드 쿼리값 변경으로 인해 쿼리값 소문자 -> 대문자로 변경
- 백엔드에서 보내주는 게시글 전체 개수 postDataLength에 저장해서 페이지네이션 totalPages 값 넘기는 걸로 코드 수정
- 정렬 셀렉트바 선택에 따라 쿼리값 변경해주는 handleSortChange 함수 추가 -> 쿼리값은 변경되지만 데이터 렌더링이 되지 않음
