### PR TITLE
✨[Feature/component/#15] 카카오 로그인 기능 구현

### DIFF
--- a/solumon-front/src/pages/ReDirect.jsx
+++ b/solumon-front/src/pages/ReDirect.jsx
@@ -39,7 +39,7 @@ function ReDirect() {
     }
   };
 
-  // getKakaoAccessToken 함수 응답의 is_member 값이 true일 때
+  // getKakaoAccessToken 함수 응답의 is_member 값이 true일 때(이미 카카오 회원가입이 되어있을 때)
   // 발급받은 카카오 로그인 액세스 토큰으로 로그인 요청 후 사이트 액세스 토큰 발급받는 함수
   const getKakaoLoginToken = async () => {
     const KAKAO_TOKEN = window.localStorage.getItem('kakaoToken');

--- a/solumon-front/src/pages/ReDirect.jsx
+++ b/solumon-front/src/pages/ReDirect.jsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
+import { useRecoilState } from 'recoil';
+import { GeneralUserInfo } from '../recoil/AllAtom';
+
+import Loading from '../components/Loading';
+
+function ReDirect() {
+  let code = new URL(window.location.href).searchParams.get('code');
+
+  const [generalUserInfo, setGeneralUserInfo] = useRecoilState(GeneralUserInfo);
+  const navigate = useNavigate();
+
+  // url 꼬다리 ?code=${code}
+
+  // 카카오 로그인 진행 후 발급받은 인가코드로 백엔드에 카카오 액세스 토큰 요청
+  const getKakaoAccessToken = async () => {
+    try {
+      const response = await axios.get(
+        `http://solumon.site:8080/user/start/kakao?code=${code}`,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+
+      if (response.status === 200) {
+        const json = response.data;
+        console.log(json);
+        window.localStorage.setItem('kakaoToken', json.kakao_access_token);
+        json.is_member ? getKakaoLoginToken() : navigate('/user/sign-up/kakao');
+      } else {
+        console.error('로그인 실패');
+      }
+    } catch (error) {
+      console.error('An error occurred:', error);
+    }
+  };
+
+  // getKakaoAccessToken 함수 응답의 is_member 값이 true일 때
+  // 발급받은 카카오 로그인 액세스 토큰으로 로그인 요청 후 사이트 액세스 토큰 발급받는 함수
+  const getKakaoLoginToken = async () => {
+    const KAKAO_TOKEN = window.localStorage.getItem('kakaoToken');
+    try {
+      const response = await axios.post(
+        'http://solumon.site:8080/user/sign-in/kakao',
+        { kakao_access_token: KAKAO_TOKEN },
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          withCredentials: true,
+        },
+      );
+
+      if (response.status === 200) {
+        const json = response.data;
+        console.log(json);
+        window.localStorage.setItem(
+          'userInfo',
+          JSON.stringify({
+            accessToken: json.access_token,
+            firstLogIn: json.is_first_log_in,
+            memberId: json.member_id,
+            nickname: json.nickname,
+          }),
+        );
+        navigate('/post-list');
+      } else {
+        console.error('로그인 실패');
+      }
+    } catch (error) {
+      console.error('An error occurred:', error);
+    }
+  };
+
+  useEffect(() => {
+    getKakaoAccessToken();
+  }, []);
+
+  return <Loading />;
+}
+
+export default ReDirect;

--- a/solumon-front/src/pages/sign-up/SignUpKakao.jsx
+++ b/solumon-front/src/pages/sign-up/SignUpKakao.jsx
@@ -5,22 +5,41 @@ import theme from '../../style/theme';
 import Button from '../../components/Button';
 
 function SignUpKakao() {
+  const kakaoToken = window.localStorage.getItem('kakaoToken');
+  const KAKAO_TOKEN = kakaoToken;
+
   const [userData, setUserData] = useState('name');
   const [nickname, setNickname] = useState('');
   const [email, setEmail] = useState('test@kakao.com');
 
+  // 사이트에 카카오 회원가입이 처음일 때 회원가입 하는 함수
+  // 이 과정이 완료된 후에는 카카오 로그인을 시도하면
+  // Redirect 페이지에서 자동으로 로그인 처리됨
   const handleSignUpButton = async (e) => {
     e.preventDefault();
     if (nickname.length > 0) {
       try {
         const response = await axios.post(
-          'https://jsonplaceholder.typicode.com/users',
+          'http://solumon.site:8080/user/sign-up/kakao',
           {
+            kakao_access_token: KAKAO_TOKEN,
             nickname: nickname,
           },
+          {
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            withCredentials: true,
+          },
         );
+        if (response.status === 200) {
+          const json = response.data;
+          console.log(json);
+        } else {
+          console.error('카카오 회원가입 실패');
+        }
       } catch (error) {
-        console.error(error);
+        console.log(`Something Wrong: ${error.message}`);
       }
     } else {
       alert('닉네임을 입력해 주세요.');


### PR DESCRIPTION
> 카카오 로그인 진행
1. "/login" 페이지에서 카카오 로그인 버튼 클릭 - Login.jsx
2. 카카오 로그인 후 "/user/start/kakao" 페이지에서 백엔드 서버에 카카오 액세스 토큰 요청 - Redirect.jsx
3. 백엔드 응답 값 중 is_member 값이 false이면(=카카오 로그인이 처음) "/user/sign-up/kakao" 페이지에서 카카오 회원가입 진행 - SignUpKakao.jsx

<hr />

> Redirect.jsx

- 카카오 로그인 후 발급받은 인가코드로 백엔드 서버에 카카오 액세스 토큰을 요청하는 getKakaoAccessToken 함수 작성
- getKakaoAccessToken 함수 응답의 is_member 값이 true일 때(이미 카카오 회원가입이 되어있을 때), 발급받은 카카오 로그인 액세스 토큰으로 백엔드 서버에 로그인 요청 후 사이트 액세스 토큰 발급받는 getKakaoLoginToken 함수 작성

> SignUpKakao.jsx
- 카카오 로그인이 처음일 때 발급받은 카카오 액세스 토큰으로 사이트 회원가입을 요청하는 '/user/sign-up/kakao' API와 연동

