### PR TITLE
:sparkles: [feature/component/#3] 투표 종료 여부를 나타내는 Badge 컴포넌트 생성

### DIFF
--- a/solumon-front/src/components/Badge.jsx
+++ b/solumon-front/src/components/Badge.jsx
@@ -1,0 +1,40 @@
+import styled, { ThemeProvider } from 'styled-components';
+import theme from '../style/theme';
+import PropTypes from 'prop-types';
+
+function Badge({ end_at }) {
+  const isVoteExpired = (endDate) => {
+    const currentTime = new Date().getTime();
+    const voteEndTime = new Date(endDate).getTime();
+    console.log(currentTime);
+    return currentTime > voteEndTime;
+  };
+
+  return (
+    <ThemeProvider theme={theme}>
+      {end_at && isVoteExpired(end_at) ? (
+        <Wrapper>
+          <StyledSpan>투표종료</StyledSpan>
+        </Wrapper>
+      ) : (
+        <></>
+      )}
+    </ThemeProvider>
+  );
+}
+
+Badge.propTypes = {
+  end_at: PropTypes.string.isRequired,
+};
+
+export default Badge;
+
+const Wrapper = styled.div``;
+
+const StyledSpan = styled.span`
+  color: ${({ theme }) => theme.dark_purple};
+  background-color: ${({ theme }) => theme.light_purple};
+  font-weight: 600;
+  border-radius: 8px;
+  padding: 2px 4px;
+`;


### PR DESCRIPTION
**기존 서버를 사용할 때** 
: TabsComponent를 사용해서 투표가 진행중인 고민과 투표가 종료된 고민을 나눠서 정렬하던 방식으로 화면을 구현

<br />

**Firebase로 대체한 후**
: 페이지에서 게시글 데이터의 투표 종료일을 props로 받아온 후 현재 날짜와 비교하여 투표가 종료되었을 때만 투표종료 뱃지가 나타나도록 화면을 구현
